### PR TITLE
跳过ps -ef的首行

### DIFF
--- a/12-awk-count-process/count_process.awk
+++ b/12-awk-count-process/count_process.awk
@@ -1,5 +1,6 @@
 #!/bin/awk -f
 
+BEGIN{ getline; }
 {
     num[$1]++
 }


### PR DESCRIPTION
`ps -ef`首行的`$1`为`UID`，这个并不是用户名，只是列名，不应该出现在统计结果中。